### PR TITLE
Allow configure enabled option

### DIFF
--- a/src/Inspector.svelte
+++ b/src/Inspector.svelte
@@ -1,6 +1,6 @@
 <script>
   import { onMount } from 'svelte';
-  let enabled = true;
+  export let enabled = true;
   let open;
   let x;
   let y;

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 import Inspector from './Inspector.svelte';
 
-export default function () {
+export default function ({enabled=true}) {
   return {
     name: 'vite-plugin-svelte-inspector',
     enforce: 'pre',
@@ -13,7 +13,7 @@ export default function () {
           '\n' +
           Inspector +
           `
-        new $({ target: document.body });
+        new $({ target: document.body, props: { enabled: ${enabled} } });
       `
         );
       }


### PR DESCRIPTION
Hi!

I'd like to use this plugin and be disabled by default, to be less intrusive at the beginning.

With that MR, we can set the plugin with the options, like:

```
kit: {
    vite: {
        plugins:  [
            Inspector({enabled: false})
        ],
    },
}
```